### PR TITLE
Getting started improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ typesense.key=xyz
 ```
 
 ### Via Docker Compose
-You can also simply use the provided `docker-compose.yml` file to run the service and a typesense instance. The docker image for the TypeAPI is stored in the GitHub Container Registry: `ghcr.io/fc4e-t4-3/dtr-toolkit:latest`. So if you want a simple setup, just run `docker-compose up`in the same folder as the `docker-compose.yml` to start the containers.
+You can also simply use the provided `docker-compose.yml` file to run the service and a typesense instance. The docker image for the TypeAPI is stored in the GitHub Container Registry: `ghcr.io/fc4e-t4-3/dtr-toolkit:latest`. So if you want a simple setup, just run `docker compose up`in the same folder as the `docker-compose.yml` to start the containers.
 ## Usage
 Once the application is running, you can access the Swagger UI at http://localhost:8080.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,4 +15,4 @@ services:
     environment:
       - "SPRING_PROFILES_ACTIVE=default"
       - "TYPESENSE_URL=typesense"
-      - "TYPESEMSE_KEY=xyz"
+      - "TYPESENSE_KEY=xyz"

--- a/src/main/java/com/fce4/dtrtoolkit/Controllers/TypeController.java
+++ b/src/main/java/com/fce4/dtrtoolkit/Controllers/TypeController.java
@@ -46,7 +46,7 @@ public class TypeController {
     @Autowired
     TypeService typeService;
 
-    @Operation(summary = "Retrieve a single schema element data type.",
+    @Operation(summary = "Retrieve a single data type or profile.",
             description= "This supports as of now BasicInfoTypes, InfoTypes and Profiles registered in one of the supported DTR's.")
     @CrossOrigin
     @RequestMapping(value = "/v1/types/{prefix}/{suffix}", method = RequestMethod.GET,  produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
@@ -73,7 +73,7 @@ public class TypeController {
         return new ResponseEntity<String>(type.toString(), responseHeaders, HttpStatus.OK);
     }
 
-    @Operation(summary = "Generate a JSON schema for a data type..",
+    @Operation(summary = "Generate a JSON schema for a data type or profile.",
             description= "This supports as of now BasicInfoTypes, InfoTypes and Profiles registered in one of the supported DTR's.")
     @CrossOrigin
     @RequestMapping(value = "/v1/types/schema/{prefix}/{suffix}", method = RequestMethod.GET,  produces = {MediaType.APPLICATION_JSON_VALUE})


### PR DESCRIPTION
Based on my experience to run the type-api using the docker compose file (which was really easy) I found a typo in the compose file and two things in the documentation that I found misleading. I “fixed” this based on what I think was meant, but you definitely need to check if it makes sense.

About the typo: The docker compose setup worked without fixing the typo. Which was confusing at first, but I saw the api key is also set to "xyz" in the `application.properties`, so it makes sense it worked.

About the README file: The `docker-compose` command was deprecated for a while, and I believe it was left unmaintained in 2023, so one should use the new `docker compose` sub-command instead. Therefore, I thought it is probably a good idea not to use the old command in the README, although I am not sure if the docker-compose command is a redirection in the meanwhile.

I enabled the modification of the branch by maintainers, so you can simply push on the branch. This should make corrections easy :)